### PR TITLE
Remove kDLCPUPinned

### DIFF
--- a/include/dgl/aten/coo.h
+++ b/include/dgl/aten/coo.h
@@ -134,7 +134,7 @@ struct COOMatrix {
   * \brief Pin the row, col and data (if not Null) of the matrix.
   * \note This is an in-place method. Behavior depends on the current context,
   *       kDLCPU: will be pinned;
-  *       kDLCPUPinned: directly return;
+  *       IsPinned: directly return;
   *       kDLGPU: invalid, will throw an error.
   *       The context check is deferred to pinning the NDArray.
   */
@@ -149,7 +149,7 @@ struct COOMatrix {
   /*!
   * \brief Unpin the row, col and data (if not Null) of the matrix.
   * \note This is an in-place method. Behavior depends on the current context,
-  *       kDLCPUPinned: will be unpinned;
+  *       IsPinned: will be unpinned;
   *       others: directly return.
   *       The context check is deferred to unpinning the NDArray.
   */

--- a/include/dgl/aten/csr.h
+++ b/include/dgl/aten/csr.h
@@ -127,7 +127,7 @@ struct CSRMatrix {
   * \brief Pin the indptr, indices and data (if not Null) of the matrix.
   * \note This is an in-place method. Behavior depends on the current context,
   *       kDLCPU: will be pinned;
-  *       kDLCPUPinned: directly return;
+  *       IsPinned: directly return;
   *       kDLGPU: invalid, will throw an error.
   *       The context check is deferred to pinning the NDArray.
   */
@@ -142,7 +142,7 @@ struct CSRMatrix {
   /*!
   * \brief Unpin the indptr, indices and data (if not Null) of the matrix.
   * \note This is an in-place method. Behavior depends on the current context,
-  *       kDLCPUPinned: will be unpinned;
+  *       IsPinned: will be unpinned;
   *       others: directly return.
   *       The context check is deferred to unpinning the NDArray.
   */

--- a/include/dgl/aten/macro.h
+++ b/include/dgl/aten/macro.h
@@ -43,7 +43,7 @@
  */
 #ifdef DGL_USE_CUDA
 #define ATEN_XPU_SWITCH_CUDA(val, XPU, op, ...) do {            \
-  if ((val) == kDLCPU || (val) == kDLCPUPinned) {               \
+  if ((val) == kDLCPU) {                                        \
     constexpr auto XPU = kDLCPU;                                \
     {__VA_ARGS__}                                               \
   } else if ((val) == kDLGPU) {                                 \
@@ -233,7 +233,7 @@
   });
 
 #define CHECK_VALID_CONTEXT(VAR1, VAR2)                                                   \
-  CHECK(((VAR1)->ctx == (VAR2)->ctx) || (VAR1).IsPinned())        \
+  CHECK(((VAR1)->ctx == (VAR2)->ctx) || (VAR1).IsPinned())                                \
     << "Expected " << (#VAR2) << "(" << (VAR2)->ctx << ")" << " to have the same device " \
     << "context as " << (#VAR1) << "(" << (VAR1)->ctx << "). "                            \
     << "Or " << (#VAR1) << "(" << (VAR1)->ctx << ")" << " is pinned";
@@ -246,7 +246,7 @@
  * If csr is pinned, array's context will conduct the actual operation.
  */
 #define ATEN_CSR_SWITCH_CUDA_UVA(csr, array, XPU, IdType, op, ...) do { \
-  CHECK_VALID_CONTEXT(csr.indices, array);                                \
+  CHECK_VALID_CONTEXT(csr.indices, array);                              \
   ATEN_XPU_SWITCH_CUDA(array->ctx.device_type, XPU, op, {               \
     ATEN_ID_TYPE_SWITCH((csr).indptr->dtype, IdType, {                  \
       {__VA_ARGS__}                                                     \
@@ -264,7 +264,7 @@
   });
 
 // Macro to dispatch according to device context and index type.
-#define ATEN_COO_SWITCH_CUDA(coo, XPU, IdType, op, ...)               \
+#define ATEN_COO_SWITCH_CUDA(coo, XPU, IdType, op, ...)          \
   ATEN_XPU_SWITCH_CUDA((coo).row->ctx.device_type, XPU, op, {    \
     ATEN_ID_TYPE_SWITCH((coo).row->dtype, IdType, {              \
       {__VA_ARGS__}                                              \

--- a/include/dgl/runtime/ndarray.h
+++ b/include/dgl/runtime/ndarray.h
@@ -176,7 +176,7 @@ class NDArray {
    *        on the underlying DLTensor.
    * \note This is an in-place method. Behavior depends on the current context,
    *       kDLCPU: will be pinned;
-   *       kDLCPUPinned: directly return;
+   *       IsPinned: directly return;
    *       kDLGPU: invalid, will throw an error.
    */
   inline void PinMemory_();
@@ -184,14 +184,14 @@ class NDArray {
    * \brief In-place method to unpin the current array by calling UnpinData
    *        on the underlying DLTensor.
    * \note This is an in-place method. Behavior depends on the current context,
-   *       kDLCPUPinned: will be unpinned;
+   *       IsPinned: will be unpinned;
    *       others: directly return.
    */
   inline void UnpinMemory_();
   /*!
    * \brief Check if the array is pinned.
    */
-  bool IsPinned() const;
+  inline bool IsPinned() const;
   /*!
    * \brief Load NDArray from stream
    * \param stream The input data stream
@@ -299,7 +299,7 @@ class NDArray {
    * \note Data of the given array will be pinned inplace.
    *       Behavior depends on the current context,
    *       kDLCPU: will be pinned;
-   *       kDLCPUPinned: directly return;
+   *       IsPinned: directly return;
    *       kDLGPU: invalid, will throw an error.
    */
   DGL_DLL static void PinData(DLTensor* tensor);
@@ -309,10 +309,17 @@ class NDArray {
    * \param tensor The array to be unpinned.
    * \note Data of the given array will be unpinned inplace.
    *       Behavior depends on the current context,
-   *       kDLCPUPinned: will be unpinned;
+   *       IsPinned: will be unpinned;
    *       others: directly return.
    */
   DGL_DLL static void UnpinData(DLTensor* tensor);
+
+  /*!
+   * \brief Function check if the data of a DLTensor is pinned.
+   * \param tensor The array to be checked.
+   * \return true if pinned.
+   */
+  DGL_DLL static bool IsDataPinned(DLTensor* tensor);
 
   // internal namespace
   struct Internal;
@@ -481,6 +488,11 @@ inline void NDArray::PinMemory_() {
 inline void NDArray::UnpinMemory_() {
   CHECK(data_ != nullptr);
   UnpinData(&(data_->dl_tensor));
+}
+
+inline bool NDArray::IsPinned() const {
+  CHECK(data_ != nullptr);
+  return IsDataPinned(&(data_->dl_tensor));
 }
 
 inline int NDArray::use_count() const {

--- a/python/dgl/_ffi/_ctypes/ndarray.py
+++ b/python/dgl/_ffi/_ctypes/ndarray.py
@@ -82,8 +82,6 @@ class NDArrayBase(object):
         Indicates the alignment requirement when converting to dlpack. Will copy to a
         new tensor if the alignment requirement is not satisfied.
         0 means no alignment requirement.
-        Will copy to a new tensor if the array is pinned because some backends,
-        e.g., pytorch, do not support kDLCPUPinned device type.
 
 
         Returns

--- a/src/array/cuda/array_index_select.cu
+++ b/src/array/cuda/array_index_select.cu
@@ -27,7 +27,7 @@ NDArray IndexSelect(NDArray array, IdArray index) {
     shape.emplace_back(array->shape[d]);
   }
 
-  // use index->ctx for kDLCPUPinned array
+  // use index->ctx for pinned array
   NDArray ret = NDArray::Empty(shape, array->dtype, index->ctx);
   if (len == 0)
     return ret;

--- a/src/graph/heterograph.h
+++ b/src/graph/heterograph.h
@@ -236,7 +236,7 @@ class HeteroGraph : public BaseHeteroGraph {
   * \brief Pin all relation graphs of the current graph.
   * \note The graph will be pinned inplace. Behavior depends on the current context,
   *       kDLCPU: will be pinned;
-  *       kDLCPUPinned: directly return;
+  *       IsPinned: directly return;
   *       kDLGPU: invalid, will throw an error.
   *       The context check is deferred to pinning the NDArray.
   */
@@ -245,7 +245,7 @@ class HeteroGraph : public BaseHeteroGraph {
   /*!
   * \brief Unpin all relation graphs of the current graph.
   * \note The graph will be unpinned inplace. Behavior depends on the current context,
-  *       kDLCPUPinned: will be unpinned;
+  *       IsPinned: will be unpinned;
   *       others: directly return.
   *       The context check is deferred to unpinning the NDArray.
   */

--- a/src/graph/heterograph_capi.cc
+++ b/src/graph/heterograph_capi.cc
@@ -173,13 +173,7 @@ DGL_REGISTER_GLOBAL("heterograph_index._CAPI_DGLHeteroDataType")
 DGL_REGISTER_GLOBAL("heterograph_index._CAPI_DGLHeteroContext")
 .set_body([] (DGLArgs args, DGLRetValue* rv) {
     HeteroGraphRef hg = args[0];
-    // The Python side only recognizes CPU and GPU device type.
-    // Use is_pinned() to checked whether the object is
-    // on page-locked memory
-    if (hg->Context().device_type == kDLCPUPinned)
-      *rv = DLContext{kDLCPU, 0};
-    else
-      *rv = hg->Context();
+    *rv = hg->Context();
   });
 
 DGL_REGISTER_GLOBAL("heterograph_index._CAPI_DGLHeteroIsPinned")

--- a/src/graph/unit_graph.h
+++ b/src/graph/unit_graph.h
@@ -214,7 +214,7 @@ class UnitGraph : public BaseHeteroGraph {
   * \brief Pin the in_csr_, out_scr_ and coo_ of the current graph.
   * \note The graph will be pinned inplace. Behavior depends on the current context,
   *       kDLCPU: will be pinned;
-  *       kDLCPUPinned: directly return;
+  *       IsPinned: directly return;
   *       kDLGPU: invalid, will throw an error.
   *       The context check is deferred to pinning the NDArray.
   */
@@ -223,7 +223,7 @@ class UnitGraph : public BaseHeteroGraph {
   /*!
   * \brief Unpin the in_csr_, out_scr_ and coo_ of the current graph.
   * \note The graph will be unpinned inplace. Behavior depends on the current context,
-  *       kDLCPUPinned: will be unpinned;
+  *       IsPinned: will be unpinned;
   *       others: directly return.
   *       The context check is deferred to unpinning the NDArray.
   */

--- a/src/runtime/ndarray.cc
+++ b/src/runtime/ndarray.cc
@@ -64,7 +64,7 @@ struct NDArray::Internal {
       ptr->mem = nullptr;
     } else if (ptr->dl_tensor.data != nullptr) {
       // if the array is still pinned before freeing, unpin it.
-      if (ptr->dl_tensor.ctx.device_type == kDLCPUPinned) {
+      if (IsDataPinned(&(ptr->dl_tensor))) {
         UnpinData(&(ptr->dl_tensor));
       }
       dgl::runtime::DeviceAPI::Get(ptr->dl_tensor.ctx)->FreeDataSpace(
@@ -206,19 +206,6 @@ NDArray NDArray::EmptyShared(const std::string &name,
   return ret;
 }
 
-inline DLContext GetDevice(DLContext ctx) {
-  switch (ctx.device_type) {
-    case kDLCPU:
-    case kDLGPU:
-      return ctx;
-      break;
-    default:
-      // fallback to CPU
-      return DLContext{kDLCPU, 0};
-      break;
-  }
-}
-
 NDArray NDArray::Empty(std::vector<int64_t> shape,
                        DLDataType dtype,
                        DLContext ctx) {
@@ -226,7 +213,7 @@ NDArray NDArray::Empty(std::vector<int64_t> shape,
   if (td->IsAvailable())
     return td->Empty(shape, dtype, ctx);
 
-  NDArray ret = Internal::Create(shape, dtype, GetDevice(ctx));
+  NDArray ret = Internal::Create(shape, dtype, ctx);
   // setup memory content
   size_t size = GetDataSize(ret.data_->dl_tensor);
   size_t alignment = GetDataAlignment(ret.data_->dl_tensor);
@@ -261,7 +248,7 @@ void NDArray::CopyFromTo(DLTensor* from,
 
   // Use the context that is *not* a cpu context to get the correct device
   // api manager.
-  DGLContext ctx = GetDevice(from->ctx).device_type != kDLCPU ? from->ctx : to->ctx;
+  DGLContext ctx = from->ctx.device_type != kDLCPU ? from->ctx : to->ctx;
 
   DeviceAPI::Get(ctx)->CopyDataFromTo(
     from->data, static_cast<size_t>(from->byte_offset),
@@ -270,28 +257,21 @@ void NDArray::CopyFromTo(DLTensor* from,
 }
 
 void NDArray::PinData(DLTensor* tensor) {
-  // Only need to call PinData once, since the pinned memory can be seen
-  // by all CUDA contexts, not just the one that performed the allocation
-  if (tensor->ctx.device_type == kDLCPUPinned) return;
+  if (IsDataPinned(tensor)) return;
   CHECK_EQ(tensor->ctx.device_type, kDLCPU)
     << "Only NDArray on CPU can be pinned";
   DeviceAPI::Get(kDLGPU)->PinData(tensor->data, GetDataSize(*tensor));
-  tensor->ctx = DLContext{kDLCPUPinned, 0};
 }
 
 void NDArray::UnpinData(DLTensor* tensor) {
-  if (tensor->ctx.device_type != kDLCPUPinned) return;
+  if (!IsDataPinned(tensor)) return;
   DeviceAPI::Get(kDLGPU)->UnpinData(tensor->data);
-  tensor->ctx = DLContext{kDLCPU, 0};
 }
 
 template<typename T>
 NDArray NDArray::FromVector(const std::vector<T>& vec, DLContext ctx) {
   const DLDataType dtype = DLDataTypeTraits<T>::dtype;
   int64_t size = static_cast<int64_t>(vec.size());
-  if (ctx.device_type == kDLCPUPinned)
-    // Temporary set the device to CPU - OK to modify in-place since ctx is passed-by-value anyway.
-    ctx.device_type = kDLCPU;
   NDArray ret = NDArray::Empty({size}, dtype, ctx);
   DeviceAPI::Get(ctx)->CopyDataFromTo(
       vec.data(),
@@ -347,11 +327,7 @@ std::shared_ptr<SharedMemory> NDArray::GetSharedMem() const {
   return this->data_->mem;
 }
 
-bool NDArray::IsPinned() const {
-  CHECK(data_ != nullptr);
-  if (data_->dl_tensor.ctx.device_type == kDLCPUPinned)
-    return true;
-  auto tensor = &data_->dl_tensor;
+bool NDArray::IsDataPinned(DLTensor* tensor) {
   // Can only be pinned if on CPU...
   if (tensor->ctx.device_type != kDLCPU)
     return false;
@@ -505,10 +481,9 @@ int DGLArrayToDLPack(DGLArrayHandle from, DLManagedTensor** out,
   API_BEGIN();
   auto* nd_container = reinterpret_cast<NDArray::Container*>(from);
   DLTensor* nd = &(nd_container->dl_tensor);
-  if ((alignment != 0 && !is_aligned(nd->data, alignment))
-      || (nd->ctx.device_type == kDLCPUPinned)) {
+  if (alignment != 0 && !is_aligned(nd->data, alignment)) {
     std::vector<int64_t> shape_vec(nd->shape, nd->shape + nd->ndim);
-    NDArray copy_ndarray = NDArray::Empty(shape_vec, nd->dtype, GetDevice(nd->ctx));
+    NDArray copy_ndarray = NDArray::Empty(shape_vec, nd->dtype, nd->ctx);
     copy_ndarray.CopyFrom(nd);
     *out = copy_ndarray.ToDLPack();
   } else {


### PR DESCRIPTION
## Description
Remove `kDLCPUPinned` and use `IsPinned()` instead to avoid many workarounds for the device type.
@BarclayII 
